### PR TITLE
[server] コネクションごとにServiceのインスタンスが生成されることを考慮し修正

### DIFF
--- a/Server/GameModel.cs
+++ b/Server/GameModel.cs
@@ -10,12 +10,14 @@ namespace WebSocketSample.Server
         Dictionary<int, Player> players = new Dictionary<int, Player>();
         int uidCounter;
 
-        GameServer server;
+        Action<string, string> sendTo;
+        Action<string> broadcast;
 
-        public GameModel(GameServer server)
+        public GameModel(ref Action onUpdate, Action<string, string> send, Action<string> broadcast)
         {
-            this.server = server;
-            server.OnUpdate += Sync;
+            onUpdate += Sync;
+            this.sendTo = send;
+            this.broadcast = broadcast;
         }
 
         public void SubscribeServiceEvent(GameService service)
@@ -31,7 +33,7 @@ namespace WebSocketSample.Server
 
             var pingRpc = new Ping(new PingPayload("pong"));
             var pingJson = JsonConvert.SerializeObject(pingRpc);
-            server.SendTo(pingJson, senderId);
+            sendTo(pingJson, senderId);
 
             Console.WriteLine("<< Pong");
         }
@@ -45,7 +47,7 @@ namespace WebSocketSample.Server
 
             var loginResponseRpc = new LoginResponse(new LoginResponsePayload(player.Uid));
             var loginResponseJson = JsonConvert.SerializeObject(loginResponseRpc);
-            server.SendTo(loginResponseJson, senderId);
+            sendTo(loginResponseJson, senderId);
 
             Console.WriteLine(player.ToString() + " login.");
         }
@@ -79,7 +81,7 @@ namespace WebSocketSample.Server
 
             var syncRpc = new Sync(new SyncPayload(movedPlayers));
             var syncJson = JsonConvert.SerializeObject(syncRpc);
-            server.Broadcast(syncJson);
+            broadcast(syncJson);
         }
     }
 }

--- a/Server/GameModel.cs
+++ b/Server/GameModel.cs
@@ -15,9 +15,17 @@ namespace WebSocketSample.Server
         public GameModel(GameServer server)
         {
             this.server = server;
+            server.OnUpdate += Sync;
         }
 
-        public void OnPing(string senderId)
+        public void SubscribeServiceEvent(GameService service)
+        {
+            service.OnPing += OnPing;
+            service.OnLogin += OnLogin;
+            service.OnPlayerUpdate += OnPlayerUpdate;
+        }
+
+        void OnPing(string senderId)
         {
             Console.WriteLine(">> Ping");
 
@@ -28,7 +36,7 @@ namespace WebSocketSample.Server
             Console.WriteLine("<< Pong");
         }
 
-        public void OnLogin(string senderId, LoginPayload loginPayload)
+        void OnLogin(string senderId, LoginPayload loginPayload)
         {
             Console.WriteLine(">> Login");
 
@@ -42,7 +50,7 @@ namespace WebSocketSample.Server
             Console.WriteLine(player.ToString() + " login.");
         }
 
-        public void OnPlayerUpdate(string senderId, PlayerUpdatePayload playerUpdatePayload)
+        void OnPlayerUpdate(string senderId, PlayerUpdatePayload playerUpdatePayload)
         {
             Console.WriteLine(">> PlayerUpdate");
 
@@ -53,7 +61,7 @@ namespace WebSocketSample.Server
             }
         }
 
-        public void Sync()
+        void Sync()
         {
             if (players.Count == 0) return;
 

--- a/Server/GameModel.cs
+++ b/Server/GameModel.cs
@@ -10,24 +10,15 @@ namespace WebSocketSample.Server
         Dictionary<int, Player> players = new Dictionary<int, Player>();
         int uidCounter;
 
-        Action<string, string> sendTo;
-        Action<string> broadcast;
+        public event Action<string, string> sendTo;
+        public event Action<string> broadcast;
 
-        public GameModel(ref Action onUpdate, Action<string, string> send, Action<string> broadcast)
+        public void OnUpdate()
         {
-            onUpdate += Sync;
-            this.sendTo = send;
-            this.broadcast = broadcast;
+            Sync();
         }
 
-        public void SubscribeServiceEvent(GameService service)
-        {
-            service.OnPing += OnPing;
-            service.OnLogin += OnLogin;
-            service.OnPlayerUpdate += OnPlayerUpdate;
-        }
-
-        void OnPing(string senderId)
+        public void OnPing(string senderId)
         {
             Console.WriteLine(">> Ping");
 
@@ -38,7 +29,7 @@ namespace WebSocketSample.Server
             Console.WriteLine("<< Pong");
         }
 
-        void OnLogin(string senderId, LoginPayload loginPayload)
+        public void OnLogin(string senderId, LoginPayload loginPayload)
         {
             Console.WriteLine(">> Login");
 
@@ -52,7 +43,7 @@ namespace WebSocketSample.Server
             Console.WriteLine(player.ToString() + " login.");
         }
 
-        void OnPlayerUpdate(string senderId, PlayerUpdatePayload playerUpdatePayload)
+        public void OnPlayerUpdate(string senderId, PlayerUpdatePayload playerUpdatePayload)
         {
             Console.WriteLine(">> PlayerUpdate");
 

--- a/Server/GameModel.cs
+++ b/Server/GameModel.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using WebSocketSample.RPC;
+
+namespace WebSocketSample.Server
+{
+    public class GameModel
+    {
+        Dictionary<int, Player> players = new Dictionary<int, Player>();
+        int uidCounter;
+
+        GameServer server;
+
+        public GameModel(GameServer server)
+        {
+            this.server = server;
+        }
+
+        public void OnPing(string senderId)
+        {
+            Console.WriteLine(">> Ping");
+
+            var pingRpc = new Ping(new PingPayload("pong"));
+            var pingJson = JsonConvert.SerializeObject(pingRpc);
+            server.SendTo(pingJson, senderId);
+
+            Console.WriteLine("<< Pong");
+        }
+
+        public void OnLogin(string senderId, LoginPayload loginPayload)
+        {
+            Console.WriteLine(">> Login");
+
+            var player = new Player(uidCounter++, loginPayload.Name, new Position(0f, 0f, 0f));
+            players[player.Uid] = player;
+
+            var loginResponseRpc = new LoginResponse(new LoginResponsePayload(player.Uid));
+            var loginResponseJson = JsonConvert.SerializeObject(loginResponseRpc);
+            server.SendTo(loginResponseJson, senderId);
+
+            Console.WriteLine(player.ToString() + " login.");
+        }
+
+        public void OnPlayerUpdate(string senderId, PlayerUpdatePayload playerUpdatePayload)
+        {
+            Console.WriteLine(">> PlayerUpdate");
+
+            Player player;
+            if (players.TryGetValue(playerUpdatePayload.Id, out player))
+            {
+                player.SetPosition(playerUpdatePayload.Position);
+            }
+        }
+
+        public void Sync()
+        {
+            if (players.Count == 0) return;
+
+            var movedPlayers = new List<RPC.Player>();
+            foreach (var player in players.Values)
+            {
+                if (!player.isPositionChanged) continue;
+
+                var playerRpc = new RPC.Player(player.Uid, player.Position);
+                movedPlayers.Add(playerRpc);
+                player.isPositionChanged = false;
+            }
+
+            if (movedPlayers.Count == 0) return;
+
+            var syncRpc = new Sync(new SyncPayload(movedPlayers));
+            var syncJson = JsonConvert.SerializeObject(syncRpc);
+            server.Broadcast(syncJson);
+        }
+    }
+}

--- a/Server/GameServer.cs
+++ b/Server/GameServer.cs
@@ -8,18 +8,22 @@ namespace WebSocketSample.Server
         const string SERVICE_NAME = "/";
         const ConsoleKey EXIT_KEY = ConsoleKey.Q;
 
-        public event Action OnUpdate = () => { };
+        GameModel model;
 
         WebSocketServer WebSocketServer;
 
         public GameServer(string address)
         {
-            var model = new GameModel(ref OnUpdate, SendTo, Broadcast);
+            model = new GameModel();
+            model.sendTo += SendTo;
+            model.broadcast += Broadcast;
             WebSocketServer = new WebSocketServer(address);
             WebSocketServer.AddWebSocketService<GameService>(SERVICE_NAME, () =>
             {
                 var service = new GameService();
-                model.SubscribeServiceEvent(service);
+                service.OnPing += model.OnPing;
+                service.OnLogin += model.OnLogin;
+                service.OnPlayerUpdate += model.OnPlayerUpdate;
                 return service;
             });
         }
@@ -31,7 +35,7 @@ namespace WebSocketSample.Server
 
             while (!IsInputtedExitKey())
             {
-                OnUpdate();
+                model.OnUpdate();
             }
         }
 

--- a/Server/GameServer.cs
+++ b/Server/GameServer.cs
@@ -14,7 +14,7 @@ namespace WebSocketSample.Server
 
         public GameServer(string address)
         {
-            var model = new GameModel(this);
+            var model = new GameModel(ref OnUpdate, SendTo, Broadcast);
             WebSocketServer = new WebSocketServer(address);
             WebSocketServer.AddWebSocketService<GameService>(SERVICE_NAME, () =>
             {
@@ -52,13 +52,13 @@ namespace WebSocketSample.Server
             }
         }
 
-        public void SendTo(string message, string id)
+        void SendTo(string message, string id)
         {
             WebSocketServer.WebSocketServices[SERVICE_NAME].Sessions.SendTo(message, id);
             Console.WriteLine("<< SendTo: " + id + " " + message);
         }
 
-        public void Broadcast(string message)
+        void Broadcast(string message)
         {
             WebSocketServer.WebSocketServices[SERVICE_NAME].Sessions.Broadcast(message);
             Console.WriteLine("<< Broeadcast: " + message);

--- a/Server/GameServer.cs
+++ b/Server/GameServer.cs
@@ -19,10 +19,7 @@ namespace WebSocketSample.Server
             WebSocketServer.AddWebSocketService<GameService>(SERVICE_NAME, () =>
             {
                 var service = new GameService();
-                service.OnPing += model.OnPing;
-                service.OnLogin += model.OnLogin;
-                service.OnPlayerUpdate += model.OnPlayerUpdate;
-                OnUpdate += model.Sync;
+                model.SubscribeServiceEvent(service);
                 return service;
             });
         }

--- a/Server/GameService.cs
+++ b/Server/GameService.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using Newtonsoft.Json;
 using WebSocketSharp;
 using WebSocketSharp.Server;
@@ -9,13 +8,9 @@ namespace WebSocketSample.Server
 {
     public class GameService : WebSocketBehavior
     {
-        Dictionary<int, Player> players = new Dictionary<int, Player>();
-        static int uidCounter;
-
-        public GameService(GameServer gameServer)
-        {
-            gameServer.OnUpdate += Sync;
-        }
+        public event Action<string> OnPing;
+        public event Action<string, LoginPayload> OnLogin;
+        public event Action<string, PlayerUpdatePayload> OnPlayerUpdate;
 
         protected override void OnOpen()
         {
@@ -38,19 +33,19 @@ namespace WebSocketSample.Server
             {
                 case "ping":
                     {
-                        OnPing();
+                        OnPing(ID);
                         break;
                     }
                 case "login":
                     {
                         var loginPayload = JsonConvert.DeserializeObject<Login>(e.Data).Payload;
-                        OnLogin(loginPayload);
+                        OnLogin(ID, loginPayload);
                         break;
                     }
                 case "player_update":
                     {
                         var playerUpdatePayload = JsonConvert.DeserializeObject<PlayerUpdate>(e.Data).Payload;
-                        OnPlayerUpdate(playerUpdatePayload);
+                        OnPlayerUpdate(ID, playerUpdatePayload);
                         break;
                     }
             }
@@ -59,75 +54,6 @@ namespace WebSocketSample.Server
         protected override void OnError(ErrorEventArgs e)
         {
             Console.WriteLine("WebSocket Error: " + e);
-        }
-
-        void SendTo(string message)
-        {
-            Sessions.SendTo(message, ID);
-            Console.WriteLine("<< SendTo: " + ID + " " + message);
-        }
-
-        void Broadcast(string message)
-        {
-            Sessions.Broadcast(message);
-            Console.WriteLine("<< Broeadcast: " + message);
-        }
-
-        public void OnPing()
-        {
-            Console.WriteLine(">> Ping");
-
-            var pingRpc = new Ping(new PingPayload("pong"));
-            var pingJson = JsonConvert.SerializeObject(pingRpc);
-            SendTo(pingJson);
-
-            Console.WriteLine("<< Pong");
-        }
-
-        public void OnLogin(LoginPayload loginPayload)
-        {
-            Console.WriteLine(">> Login");
-
-            var player = new Player(uidCounter++, loginPayload.Name, new Position(0f, 0f, 0f));
-            players[player.Uid] = player;
-
-            var loginResponseRpc = new LoginResponse(new LoginResponsePayload(player.Uid));
-            var loginResponseJson = JsonConvert.SerializeObject(loginResponseRpc);
-            SendTo(loginResponseJson);
-
-            Console.WriteLine(player.ToString() + " login.");
-        }
-
-        public void OnPlayerUpdate(PlayerUpdatePayload playerUpdatePayload)
-        {
-            Console.WriteLine(">> PlayerUpdate");
-
-            Player player;
-            if (players.TryGetValue(playerUpdatePayload.Id, out player))
-            {
-                player.SetPosition(playerUpdatePayload.Position);
-            }
-        }
-
-        void Sync()
-        {
-            if (players.Count == 0) return;
-
-            var movedPlayers = new List<RPC.Player>();
-            foreach (var player in players.Values)
-            {
-                if (!player.isPositionChanged) continue;
-
-                var playerRpc = new RPC.Player(player.Uid, player.Position);
-                movedPlayers.Add(playerRpc);
-                player.isPositionChanged = false;
-            }
-
-            if (movedPlayers.Count == 0) return;
-
-            var syncRpc = new Sync(new SyncPayload(movedPlayers));
-            var syncJson = JsonConvert.SerializeObject(syncRpc);
-            Broadcast(syncJson);
         }
     }
 }

--- a/Server/Server.csproj
+++ b/Server/Server.csproj
@@ -42,6 +42,7 @@
     <Compile Include="GameServer.cs" />
     <Compile Include="GameService.cs" />
     <Compile Include="MainClass.cs" />
+    <Compile Include="GameModel.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>


### PR DESCRIPTION
## 概要
リファクタリングで元の動作を破壊して、正しく動かなくなっていたので修正。

### 背景
コネクションごとにServiceのインスタンスが生成されるので、前回のリファクタリングは正しくなかった。

### やったこと

* `GameService` は受信系のみに
  * イベントで提供する
  * 送信は取り扱わない
    * 送信は `GameServer` 経由で、個別の (セッション | サービス) を意識しない

* サービス(セッション)生成時にModelは、そのサービスのイベントの購読をするように
 
