### PR TITLE
[client] シーンリロード時のMissingReferenceExceptionを解消する

### DIFF
--- a/Client/Assets/Scripts/MainController.cs
+++ b/Client/Assets/Scripts/MainController.cs
@@ -49,53 +49,54 @@ public class MainController : MonoBehaviour
         // メッセージを受信したときのハンドラ
         webSocket.OnMessage += (sender, eventArgs) =>
         {
-            Debug.Log("WebSocket Message: " + eventArgs.Data);
-
-            var header = JsonUtility.FromJson<RPC.Header>(eventArgs.Data);
-            switch (header.Method)
+            lock (MainThreadExecutor.actions)
             {
-                case "ping":
-                    {
-                        var pong = JsonUtility.FromJson<RPC.Ping>(eventArgs.Data);
-                        Debug.Log(pong.Payload.Message);
-                        break;
-                    }
-                case "login_response":
-                    {
-                        var loginResponse = JsonUtility.FromJson<RPC.LoginResponse>(eventArgs.Data);
-                        MainThreadExecutor.Enqueue(() => OnLoginResponse(loginResponse.Payload));
-                        break;
-                    }
-                case "sync":
-                    {
-                        var syncMessage = JsonUtility.FromJson<RPC.Sync>(eventArgs.Data);
-                        MainThreadExecutor.Enqueue(() => OnSync(syncMessage.Payload));
-                        break;
-                    }
-                case "spawn":
-                    {
-                        var spawnResponse = JsonUtility.FromJson<RPC.Spawn>(eventArgs.Data);
-                        MainThreadExecutor.Enqueue(() => OnSpawn(spawnResponse.Payload));
-                        break;
-                    }
-                case "delete_item":
-                    {
-                        var deleteMessage = JsonUtility.FromJson<RPC.DeleteItem>(eventArgs.Data);
-                        MainThreadExecutor.Enqueue(() => OnDeleteItem(deleteMessage.Payload));
-                        break;
-                    }
-                case "environment":
-                    {
-                        var environmentMessage = JsonUtility.FromJson<RPC.Environment>(eventArgs.Data);
-                        MainThreadExecutor.Enqueue(() => OnEnvironment(environmentMessage.Payload));
-                        break;
-                    }
-                case "delete_player":
-                    {
-                        var deletePlayerMessage = JsonUtility.FromJson<RPC.DeletePlayer>(eventArgs.Data);
-                        MainThreadExecutor.Enqueue(() => OnDeletePlayer(deletePlayerMessage.Payload));
-                        break;
-                    }
+                var header = JsonUtility.FromJson<RPC.Header>(eventArgs.Data);
+                switch (header.Method)
+                {
+                    case "ping":
+                        {
+                            var pong = JsonUtility.FromJson<RPC.Ping>(eventArgs.Data);
+                            Debug.Log(pong.Payload.Message);
+                            break;
+                        }
+                    case "login_response":
+                        {
+                            var loginResponse = JsonUtility.FromJson<RPC.LoginResponse>(eventArgs.Data);
+                            MainThreadExecutor.Enqueue(() => OnLoginResponse(loginResponse.Payload));
+                            break;
+                        }
+                    case "sync":
+                        {
+                            var syncMessage = JsonUtility.FromJson<RPC.Sync>(eventArgs.Data);
+                            MainThreadExecutor.Enqueue(() => OnSync(syncMessage.Payload));
+                            break;
+                        }
+                    case "spawn":
+                        {
+                            var spawnResponse = JsonUtility.FromJson<RPC.Spawn>(eventArgs.Data);
+                            MainThreadExecutor.Enqueue(() => OnSpawn(spawnResponse.Payload));
+                            break;
+                        }
+                    case "delete_item":
+                        {
+                            var deleteMessage = JsonUtility.FromJson<RPC.DeleteItem>(eventArgs.Data);
+                            MainThreadExecutor.Enqueue(() => OnDeleteItem(deleteMessage.Payload));
+                            break;
+                        }
+                    case "environment":
+                        {
+                            var environmentMessage = JsonUtility.FromJson<RPC.Environment>(eventArgs.Data);
+                            MainThreadExecutor.Enqueue(() => OnEnvironment(environmentMessage.Payload));
+                            break;
+                        }
+                    case "delete_player":
+                        {
+                            var deletePlayerMessage = JsonUtility.FromJson<RPC.DeletePlayer>(eventArgs.Data);
+                            MainThreadExecutor.Enqueue(() => OnDeletePlayer(deletePlayerMessage.Payload));
+                            break;
+                        }
+                }
             }
         };
 

--- a/Client/Assets/Scripts/MainController.cs
+++ b/Client/Assets/Scripts/MainController.cs
@@ -275,6 +275,8 @@ public class MainController : MonoBehaviour
 
     void RestartGame()
     {
+        webSocket.Close();
+        MainThreadExecutor.Clear();
         SceneManager.LoadScene(SceneManager.GetActiveScene().name);
     }
 }

--- a/Client/Assets/Scripts/MainThreadExecutor.cs
+++ b/Client/Assets/Scripts/MainThreadExecutor.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 
 public class MainThreadExecutor : MonoBehaviour
 {
-    static Queue<Action> actions = new Queue<Action>();    // 非同期タスク
+    public static Queue<Action> actions = new Queue<Action>();    // 非同期タスク
 
     void Update()
     {
@@ -23,6 +23,15 @@ public class MainThreadExecutor : MonoBehaviour
         lock (actions)
         {
             actions.Enqueue(action);
+        }
+    }
+
+    public static void Clear()
+    {
+        lock (actions)
+        {
+            Debug.LogWarning("actions clear");
+            actions.Clear();
         }
     }
 }


### PR DESCRIPTION
シーンリロード時に発生する

```
MissingReferenceException: The object of type 'GameObject' has been destroyed but you are still trying to access it.
Your script should either check if it is null or you should not destroy the object.
MainController.OnSync (WebSocketSample.RPC.SyncPayload payload) (at Assets/Scripts/MainController.cs:174)
MainController+<Start>c__AnonStorey1.<>m__0 () (at Assets/Scripts/MainController.cs:72)
MainThreadExecutor.Update () (at Assets/Scripts/MainThreadExecutor.cs:16)
```